### PR TITLE
chore(deps): bump androidx.exifinterface:exifinterface

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.2.0'
     implementation "androidx.core:core-ktx:1.10.0" // androidx.core:core:1.10.1
     implementation "androidx.palette:palette-ktx:1.0.0"
-    implementation "androidx.exifinterface:exifinterface:1.3.6"
+    implementation "androidx.exifinterface:exifinterface:1.4.0"
     implementation "androidx.dynamicanimation:dynamicanimation:1.0.0"
     implementation "androidx.mediarouter:mediarouter:1.7.0"
     implementation "androidx.multidex:multidex:2.0.1"


### PR DESCRIPTION
Bumps androidx.exifinterface:exifinterface from 1.3.6 to 1.4.0.

---
updated-dependencies:
- dependency-name: androidx.exifinterface:exifinterface dependency-type: direct:production update-type: version-update:semver-minor ...